### PR TITLE
batch outputs are limited to 1 for non-donating clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ import (
 
 func main() {
     // create an API client per system you want to manage
-    api := pvoutput.NewAPI("XXX", "12345")
+    api := pvoutput.NewAPI("XXX", "12345", false)
 
     // get PV generation data from your solar inverter or
     // power consumption data from your utility meter

--- a/api_test.go
+++ b/api_test.go
@@ -1,0 +1,33 @@
+package pvoutput
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewAPI(t *testing.T) {
+	a := NewAPI("foo", "bar", true)
+	assert.Equal(t, "foo", a.Key)
+	assert.Equal(t, "bar", a.SystemID)
+	assert.True(t, a.donating)
+}
+
+func TestAPIAddBatchOutput(t *testing.T) {
+	// create batch output of more than 1 item when not in donating mode
+	b := make(BatchOutput, (BatchOutputMaxSize + 1))
+	a := API{}
+	err := a.AddBatchOutput(b)
+	if assert.Error(t, err) {
+		assert.Equal(t, fmt.Sprintf("max batch size is %d", BatchOutputMaxSize), err.Error())
+	}
+
+	// in donating mode, add more outputs and trigger same error
+	a.donating = true
+	b = make(BatchOutput, (BatchOutputMaxSizeDonating + 1))
+	err = a.AddBatchOutput(b)
+	if assert.Error(t, err) {
+		assert.Equal(t, fmt.Sprintf("max batch size is %d", BatchOutputMaxSizeDonating), err.Error())
+	}
+}

--- a/output.go
+++ b/output.go
@@ -33,9 +33,12 @@ var (
 )
 
 const (
-	// BatchOutputMaxSize determines the maximum batch size
-	// this is 30 according to PVOutput's docs
-	BatchOutputMaxSize = 30
+	// BatchOutputMaxSize determines the maximum batch size when not in donating
+	// mode. Basically, batch output are disabled then
+	BatchOutputMaxSize = 1
+	// BatchOutputMaxSizeDonating determines the maximum batch size when in
+	// donating mode. This is 100 according to PVOutput's docs
+	BatchOutputMaxSizeDonating = 100
 )
 
 // Output represents the data structure for a PV Output as described
@@ -292,10 +295,6 @@ type BatchOutput []Output
 func (b BatchOutput) Encode() (string, error) {
 	if len(b) == 0 {
 		return "", errors.New("empty batch")
-	}
-
-	if len(b) > BatchOutputMaxSize {
-		return "", fmt.Errorf("max batch size is %d", BatchOutputMaxSize)
 	}
 
 	items := []string{}

--- a/output_test.go
+++ b/output_test.go
@@ -189,13 +189,6 @@ func TestEncodeBatchOutput(t *testing.T) {
 		assert.Contains(t, err.Error(), "empty")
 	}
 
-	// batches that are too big should throw an error as well
-	b = make(BatchOutput, (BatchOutputMaxSize + 1))
-	_, err = b.Encode()
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "max")
-	}
-
 	// example of documentation
 	// "Send three outputs in a single batch request"
 	b = BatchOutput{NewOutput(), NewOutput(), NewOutput()}


### PR DESCRIPTION
and are to be sent to the same API endpoint as regular outputs

Solves #1 